### PR TITLE
Add SUP_NONCE to default variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,33 @@ Demo using the following [Supfile](./example/Supfile):
 # License
 
 Licensed under the [MIT License](./LICENSE).
+
+# Supfile Tips and Tricks
+
+## Baked-In Variables
+
+`sup` provides a few baked-in variables that make developing and
+re-using Supfiles easier.
+
+ - `SUP_NETWORK` the name of the network that the command was
+   originally issued against:
+
+ - `SUP_NONCE` the date and time of the original command line
+   invocation. Useful for communicating a nonce across hosts in the
+   network. Can be overridden with by setting the environment variable
+   `SUP_NONCE`.
+
+```yaml
+commands:
+  preparerelase:
+    desc: Prepare release dir
+    run: mkdir -p /app/rels/$SUP_NONCE/
+
+  config:
+    desc: Upload/test config file.
+    upload:
+      - src: ./example.$SUP_NETWORK.cfg
+        dst: /app/rels/$SUP_NONCE/
+    run: test -f /app/rels/$SUP_NONCE/example.$SUP_NETWORK.cfg
+...
+```

--- a/README.md
+++ b/README.md
@@ -53,22 +53,22 @@ re-using Supfiles easier.
  - `SUP_NETWORK` the name of the network that the command was
    originally issued against:
 
- - `SUP_NONCE` the date and time of the original command line
+ - `SUP_TIME` the date and time of the original command line
    invocation. Useful for communicating a nonce across hosts in the
    network. Can be overridden with by setting the environment variable
-   `SUP_NONCE`.
+   `SUP_TIME`.
 
 ```yaml
 commands:
   preparerelase:
     desc: Prepare release dir
-    run: mkdir -p /app/rels/$SUP_NONCE/
+    run: mkdir -p /app/rels/$SUP_TIME/
 
   config:
     desc: Upload/test config file.
     upload:
       - src: ./example.$SUP_NETWORK.cfg
-        dst: /app/rels/$SUP_NONCE/
-    run: test -f /app/rels/$SUP_NONCE/example.$SUP_NETWORK.cfg
+        dst: /app/rels/$SUP_TIME/
+    run: test -f /app/rels/$SUP_TIME/example.$SUP_NETWORK.cfg
 ...
 ```

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -101,7 +101,7 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 	network.Env["SUP_NETWORK"] = args[0]
 
 	// Add default nonce
-	network.Env["SUP_NONCE"] = time.Now().Format("2006-01-02T15:04:05")
+	network.Env["SUP_NONCE"] = time.Now().UTC().Format("2006-01-02-15:04:05")
 	if os.Getenv("SUP_NONCE") != "" {
 		network.Env["SUP_NONCE"] = os.Getenv("SUP_NONCE")
 	}

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/pressly/sup"
 )
@@ -98,6 +99,12 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 
 	// Add default env variable with current network
 	network.Env["SUP_NETWORK"] = args[0]
+
+	// Add default nonce
+	network.Env["SUP_NONCE"] = time.Now().Format("2006-01-02T15:04:05")
+	if os.Getenv("SUP_NONCE") != "" {
+		network.Env["SUP_NONCE"] = os.Getenv("SUP_NONCE")
+	}
 
 	for _, cmd := range args[1:] {
 		// Target?

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/user"
 	"regexp"
 	"strings"
 	"text/tabwriter"
@@ -104,6 +105,17 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 	network.Env["SUP_NONCE"] = time.Now().UTC().Format("2006-01-02-15:04:05")
 	if os.Getenv("SUP_NONCE") != "" {
 		network.Env["SUP_NONCE"] = os.Getenv("SUP_NONCE")
+	}
+
+	// Add user
+	if os.Getenv("SUP_USER") != "" {
+		network.Env["SUP_USER"] = os.Getenv("SUP_USER")
+	} else {
+		u, err := user.Current()
+		if err != nil {
+			return nil, nil, err
+		}
+		network.Env["SUP_USER"] = u.Username
 	}
 
 	for _, cmd := range args[1:] {

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -102,9 +102,9 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 	network.Env["SUP_NETWORK"] = args[0]
 
 	// Add default nonce
-	network.Env["SUP_NONCE"] = time.Now().UTC().Format("2006-01-02-15:04:05")
-	if os.Getenv("SUP_NONCE") != "" {
-		network.Env["SUP_NONCE"] = os.Getenv("SUP_NONCE")
+	network.Env["SUP_TIME"] = time.Now().UTC().Format("2006-01-02-15:04:05")
+	if os.Getenv("SUP_TIME") != "" {
+		network.Env["SUP_TIME"] = os.Getenv("SUP_TIME")
 	}
 
 	// Add user

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -102,7 +102,7 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 	network.Env["SUP_NETWORK"] = args[0]
 
 	// Add default nonce
-	network.Env["SUP_TIME"] = time.Now().UTC().Format("2006-01-02-15:04:05")
+	network.Env["SUP_TIME"] = time.Now().UTC().Format(time.RFC3339)
 	if os.Getenv("SUP_TIME") != "" {
 		network.Env["SUP_TIME"] = os.Getenv("SUP_TIME")
 	}

--- a/example/Supfile
+++ b/example/Supfile
@@ -41,6 +41,9 @@ commands:
     desc: Initialize directory
     run: mkdir -p /tmp/$IMAGE
 
+  mytest:
+    run: echo $SUP_TIME
+
   build:
     desc: Build Docker image from current directory, push to Docker Hub
     # local: sup -f ./builder/Supfile $SUP_NETWORK build


### PR DESCRIPTION
SUP_NONCE is a value that is unique per invocation and can be used to
orchestrate layered deployment strategies across a fleet of hosts.

Fixes #43