### PR TITLE
Env vars should be ordered

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -95,27 +95,27 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 
 	// In case of the network.Env needs an initialization
 	if network.Env == nil {
-		network.Env = make(map[string]string)
+		network.Env = make(sup.EnvList, 0)
 	}
 
 	// Add default env variable with current network
-	network.Env["SUP_NETWORK"] = args[0]
+	network.Env.Set("SUP_NETWORK", args[0])
 
 	// Add default nonce
-	network.Env["SUP_TIME"] = time.Now().UTC().Format(time.RFC3339)
+	network.Env.Set("SUP_TIME", time.Now().UTC().Format(time.RFC3339))
 	if os.Getenv("SUP_TIME") != "" {
-		network.Env["SUP_TIME"] = os.Getenv("SUP_TIME")
+		network.Env.Set("SUP_TIME", os.Getenv("SUP_TIME"))
 	}
 
 	// Add user
 	if os.Getenv("SUP_USER") != "" {
-		network.Env["SUP_USER"] = os.Getenv("SUP_USER")
+		network.Env.Set("SUP_USER", os.Getenv("SUP_USER"))
 	} else {
 		u, err := user.Current()
 		if err != nil {
 			return nil, nil, err
 		}
-		network.Env["SUP_USER"] = u.Username
+		network.Env.Set("SUP_USER", u.Username)
 	}
 
 	for _, cmd := range args[1:] {

--- a/sup.go
+++ b/sup.go
@@ -35,11 +35,8 @@ func (sup *Stackup) Run(network *Network, commands ...*Command) error {
 	// Process all ENVs into a string of form
 	// `export FOO="bar"; export BAR="baz";`.
 	env := ``
-	for name, value := range sup.conf.Env {
-		env += `export ` + name + `="` + value + `";`
-	}
-	for name, value := range network.Env {
-		env += `export ` + name + `="` + value + `";`
+	for _, v := range append(sup.conf.Env, network.Env...) {
+		env += v.AsExport() + " "
 	}
 
 	// Create clients for every host (either SSH or Localhost).

--- a/supfile.go
+++ b/supfile.go
@@ -13,6 +13,47 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// Supfile represents the Stack Up configuration YAML file.
+type Supfile struct {
+	Networks map[string]Network  `yaml:"networks"`
+	Commands map[string]Command  `yaml:"commands"`
+	Targets  map[string][]string `yaml:"targets"`
+	Env      EnvList             `yaml:"env"`
+	Version  string              `yaml:"version"`
+}
+
+// Network is group of hosts with extra custom env vars.
+type Network struct {
+	Env       EnvList  `yaml:"env"`
+	Inventory string   `yaml:"inventory"`
+	Hosts     []string `yaml:"hosts"`
+	Bastion   string   `yaml:"bastion"` // Jump host for the environment
+}
+
+// Command represents command(s) to be run remotely.
+type Command struct {
+	Name   string   `yaml:"-"`      // Command name.
+	Desc   string   `yaml:"desc"`   // Command description.
+	Local  string   `yaml:"local"`  // Command(s) to be run locally.
+	Run    string   `yaml:"run"`    // Command(s) to be run remotelly.
+	Script string   `yaml:"script"` // Load command(s) from script and run it remotelly.
+	Upload []Upload `yaml:"upload"` // See Upload struct.
+	Stdin  bool     `yaml:"stdin"`  // Attach localhost STDOUT to remote commands' STDIN?
+	Once   bool     `yaml:"once"`   // The command should be run "once" (on one host only).
+	Serial int      `yaml:"serial"` // Max number of clients processing a task in parallel.
+
+	// API backward compatibility. Will be deprecated in v1.0.
+	RunOnce bool `yaml:"run_once"` // The command should be run once only.
+}
+
+// Upload represents file copy operation from localhost Src path to Dst
+// path of every host in a given Network.
+type Upload struct {
+	Src string `yaml:"src"`
+	Dst string `yaml:"dst"`
+	Exc string `yaml:"exclude"`
+}
+
 // EnvVar represents an environment variable
 type EnvVar struct {
 	Key   string
@@ -63,47 +104,6 @@ func (e *EnvList) Set(key, value string) {
 		Key:   key,
 		Value: value,
 	})
-}
-
-// Supfile represents the Stack Up configuration YAML file.
-type Supfile struct {
-	Networks map[string]Network  `yaml:"networks"`
-	Commands map[string]Command  `yaml:"commands"`
-	Targets  map[string][]string `yaml:"targets"`
-	Env      EnvList             `yaml:"env"`
-	Version  string              `yaml:"version"`
-}
-
-// Network is group of hosts with extra custom env vars.
-type Network struct {
-	Env       EnvList  `yaml:"env"`
-	Inventory string   `yaml:"inventory"`
-	Hosts     []string `yaml:"hosts"`
-	Bastion   string   `yaml:"bastion"` // Jump host for the environment
-}
-
-// Command represents command(s) to be run remotely.
-type Command struct {
-	Name   string   `yaml:"-"`      // Command name.
-	Desc   string   `yaml:"desc"`   // Command description.
-	Local  string   `yaml:"local"`  // Command(s) to be run locally.
-	Run    string   `yaml:"run"`    // Command(s) to be run remotelly.
-	Script string   `yaml:"script"` // Load command(s) from script and run it remotelly.
-	Upload []Upload `yaml:"upload"` // See Upload struct.
-	Stdin  bool     `yaml:"stdin"`  // Attach localhost STDOUT to remote commands' STDIN?
-	Once   bool     `yaml:"once"`   // The command should be run "once" (on one host only).
-	Serial int      `yaml:"serial"` // Max number of clients processing a task in parallel.
-
-	// API backward compatibility. Will be deprecated in v1.0.
-	RunOnce bool `yaml:"run_once"` // The command should be run once only.
-}
-
-// Upload represents file copy operation from localhost Src path to Dst
-// path of every host in a given Network.
-type Upload struct {
-	Src string `yaml:"src"`
-	Dst string `yaml:"dst"`
-	Exc string `yaml:"exclude"`
 }
 
 // NewSupfile parses configuration file and returns Supfile or error.

--- a/supfile.go
+++ b/supfile.go
@@ -32,17 +32,17 @@ func (e EnvVar) AsExport() string {
 // but maintains order, enabling late variables to reference early variables.
 type EnvList []EnvVar
 
-func (e *EnvList) UnmarshalYAML(ufn func(interface{}) error) error {
-	d := []yaml.MapItem{}
+func (e *EnvList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	items := []yaml.MapItem{}
 
-	err := ufn(&d)
+	err := unmarshal(&items)
 	if err != nil {
 		return err
 	}
 
-	*e = make(EnvList, 0, len(d))
+	*e = make(EnvList, 0, len(items))
 
-	for _, v := range d {
+	for _, v := range items {
 		e.Set(fmt.Sprintf("%v", v.Key), fmt.Sprintf("%v", v.Value))
 	}
 

--- a/supfile.go
+++ b/supfile.go
@@ -51,7 +51,14 @@ func (e *EnvList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Set key to be equal value in this list.
 func (e *EnvList) Set(key, value string) {
-	// if key exists result will be redefinition
+
+	for _, v := range *e {
+		if v.Key == key {
+			v.Value = value
+			return
+		}
+	}
+
 	*e = append(*e, EnvVar{
 		Key:   key,
 		Value: value,


### PR DESCRIPTION
Since maps in go are by definition in random order environment variables
could not rely on a previously defined value to be present. This
addresses that problem by introducing an ordered map type.

This fixes #10