### PR TITLE
[WIP] Support parsing argument for script

### DIFF
--- a/task.go
+++ b/task.go
@@ -5,13 +5,15 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 )
 
 // Task represents a set of commands to be run.
 type Task struct {
-	Run     string
-	Input   io.Reader
-	Clients []Client
+	Run       string
+	Arguments []string
+	Input     io.Reader
+	Clients   []Client
 }
 
 func CreateTasks(cmd *Command, clients []Client, env string) ([]*Task, error) {
@@ -46,7 +48,18 @@ func CreateTasks(cmd *Command, clients []Client, env string) ([]*Task, error) {
 
 	// Script. Read the file as a multiline input command.
 	if cmd.Script != "" {
-		f, err := os.Open(cmd.Script)
+		var scriptPath string
+		var arguments []string
+
+		if strings.Contains(cmd.Script, " ") {
+			scripts := strings.Split(cmd.Script, " ")
+			scriptPath = scripts[0]
+			arguments = scripts[1:]
+		} else {
+			scriptPath = cmd.Script
+		}
+
+		f, err := os.Open(scriptPath)
 		if err != nil {
 			return nil, err
 		}
@@ -57,6 +70,9 @@ func CreateTasks(cmd *Command, clients []Client, env string) ([]*Task, error) {
 
 		task := Task{
 			Run: string(data),
+		}
+		if len(arguments) > 0 {
+			task.Arguments = arguments
 		}
 		if cmd.Stdin {
 			task.Input = os.Stdin

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,44 @@
+package sup
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCreateTask_Parse_Script(t *testing.T) {
+	cmd := &Command{
+		Script: "./test/test",
+	}
+	clients := []Client{&SSHClient{}}
+	env := ""
+
+	task, _ := CreateTasks(cmd, clients, env)
+
+	if len(task) < 1 {
+		t.Errorf("Failed to parse task")
+	}
+
+	// Content is in test/script.sh
+	if strings.Trim(task[0].Run, "\n") != "echo 'test'" {
+		t.Errorf("Fail to read content of script. Expected: %s Got: %s.", "echo 'test'", task[0].Run)
+	}
+}
+
+func TestCreateTask_Parse_Script_With_Argument(t *testing.T) {
+	cmd := &Command{
+		Script: "./test/test -t test",
+	}
+	clients := []Client{&SSHClient{}}
+	env := ""
+
+	task, _ := CreateTasks(cmd, clients, env)
+
+	if len(task) < 1 {
+		t.Errorf("Failed to parse task")
+	}
+
+	// Content is in test/script.sh
+	if strings.Trim(task[0].Run, "\n") != "echo 'test'" {
+		t.Errorf("Fail to read content of script. Expected: %s Got: %s.", "echo 'test'", task[0].Run)
+	}
+}

--- a/test/test
+++ b/test/test
@@ -1,0 +1,1 @@
+echo 'test'


### PR DESCRIPTION
This allows us to specified:

```
task_name:
    desc: Script with argument
    script: ./test/script.sh -type cleanup -arg 12
```

The way it works is it run `sh` with argument, and pass script content to `stdin` like this:

```
/bin/sh <(echo 'script content...') arg1 arg2...
```

On current version, we will get this error:

```
CreateTasks(): open ./test/script.sh -type cleanup -arg 12: no such file or directory
```

need to write some more tests.