### PR TITLE
[WIP] Added support to RSYNC upload

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,4 +13,6 @@ type Client interface {
 	Stdin() io.WriteCloser
 	Stderr() io.Reader
 	Stdout() io.Reader
+	GetHost() string
+	GetUser() string
 }

--- a/localhost.go
+++ b/localhost.go
@@ -98,3 +98,11 @@ func (c *LocalhostClient) Write(p []byte) (n int, err error) {
 func (c *LocalhostClient) WriteClose() error {
 	return c.stdin.Close()
 }
+
+func (c *LocalhostClient) GetHost() string {
+	return "localhost"
+}
+
+func (c *LocalhostClient) GetUser() string {
+	return c.user
+}

--- a/rsync.go
+++ b/rsync.go
@@ -1,0 +1,11 @@
+package sup
+
+import (
+	"fmt"
+	"strings"
+)
+
+func NewRSyncCommand(path, dst, user, host string) string {
+	hostPort := strings.Split(host, ":")
+	return fmt.Sprintf("rsync -ac --port %s %s %s@%s:%s", hostPort[1], path, user, hostPort[0], dst)
+}

--- a/ssh.go
+++ b/ssh.go
@@ -260,3 +260,11 @@ func (c *SSHClient) Write(p []byte) (n int, err error) {
 func (c *SSHClient) WriteClose() error {
 	return c.remoteStdin.Close()
 }
+
+func (c *SSHClient) GetHost() string {
+	return c.host
+}
+
+func (c *SSHClient) GetUser() string {
+	return c.user
+}


### PR DESCRIPTION
Now you are able to upload your files using rsync, is similar to the `upload` method, but uses `rsync` command instead. The flags at command are: `-a` for archive mode and `-c` to check files that need to be sync by checking the hash of the file.

Example of config:

```YAML
version: 0.3

env:
  TMP_DIR: /tmp/mydir

networks:
  local:
    hosts:
      - localhost

  dev:
    hosts:
      - docker@192.168.99.100
      - docker@192.168.99.102

commands:
  pre-build:
    run: mkdir $TMP_DIR; exit 0

  build:
    rsync:
      - src: ./src/
        dst: $TMP_DIR

  test:
    run: $TMP_DIR/test.sh

targets:
  deploy:
    - pre-build
    - build
    - test
```