### PR TITLE
Allow ssh key override

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Stack Up is a simple deployment tool that performs given set of commands on mult
 | Option            | Description                      |
 |-------------------|----------------------------------|
 | `-f Supfile`      | Custom path to Supfile           |
+| `-i`, `sshKey`    | Set the the ssh key to use       |
 | `-e`, `--env=[]`  | Set environment variables        |
 | `--only REGEXP`   | Filter hosts matching regexp     |
 | `--except REGEXP` | Filter out hosts matching regexp |
@@ -43,6 +44,8 @@ networks:
             - api1.example.com
             - api2.example.com
             - api3.example.com
+        # Optional, override the ssh key to use for this network
+        ssh-key: ~/.ssh/prodKey
     staging:
         # fetch dynamic list of hosts
         inventory: curl http://example.com/latest/meta-data/hostname

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -16,6 +16,7 @@ import (
 var (
 	supfile     string
 	envVars     flagStringSlice
+	sshKey      string
 	onlyHosts   string
 	exceptHosts string
 
@@ -46,6 +47,7 @@ func (f *flagStringSlice) Set(value string) error {
 func init() {
 	flag.StringVar(&supfile, "f", "./Supfile", "Custom path to Supfile")
 	flag.Var(&envVars, "e", "Set environment variables")
+	flag.StringVar(&sshKey, "i", "", "Set the ssh key to use")
 	flag.Var(&envVars, "env", "Set environment variables")
 	flag.StringVar(&onlyHosts, "only", "", "Filter hosts using regexp")
 	flag.StringVar(&exceptHosts, "except", "", "Filter out hosts using regexp")
@@ -280,6 +282,7 @@ func main() {
 	}
 	app.Debug(debug)
 	app.Prefix(!disablePrefix)
+	app.SSHKey(sshKey)
 
 	// Run all the commands in the given network.
 	err = app.Run(network, commands...)

--- a/supfile.go
+++ b/supfile.go
@@ -26,6 +26,7 @@ type Network struct {
 	Env       EnvList  `yaml:"env"`
 	Inventory string   `yaml:"inventory"`
 	Hosts     []string `yaml:"hosts"`
+	SSHKey    string   `yaml:"ssh-key"`
 	Bastion   string   `yaml:"bastion"` // Jump host for the environment
 }
 


### PR DESCRIPTION
Implement the "easy" solution requested in #86.

This adds two features:
* Allow the user to override ssh-key on a per network basis in Supfile
* Allow the user to override the ssh-key on the command line by using the `-i` flag