### PR TITLE
Update README.md - running Sup from Supfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,11 +277,11 @@ Top-level Supfile calls `sup` with Supfiles from sub-projects:
 ```yaml
  restart-scheduler:
     desc: Restart scheduler
-    run: >
+    local: >
       sup -f ./services/scheduler/Supfile $SUP_ENV $SUP_NETWORK restart
  db-up:
     desc: Migrate database
-    run: >
+    local: >
       sup -f ./database/Supfile $SUP_ENV $SUP_NETWORK up
 ```
 


### PR DESCRIPTION
using "run" will try to execute sup on the Destination network (machines) while according to documentation authors intent I assume it was meant to run it locally per sub folder project. hence replaced run with 'local' which worked for me.