### PR TITLE
Add extra ssh auth method

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -19,6 +19,7 @@ type SSHClient struct {
 	conn         *ssh.Client
 	sess         *ssh.Session
 	user         string
+	password     string
 	host         string
 	remoteStdin  io.WriteCloser
 	remoteStdout io.Reader
@@ -137,6 +138,7 @@ func (c *SSHClient) ConnectWith(host string, dialer SSHDialFunc) error {
 		User: c.user,
 		Auth: []ssh.AuthMethod{
 			authMethod,
+			ssh.Password(c.password),
 		},
 	}
 

--- a/sup.go
+++ b/sup.go
@@ -40,7 +40,9 @@ func (sup *Stackup) Run(network *Network, envVars EnvList, commands ...*Command)
 	// Create clients for every host (either SSH or Localhost).
 	var bastion *SSHClient
 	if network.Bastion != "" {
-		bastion = &SSHClient{}
+		bastion = &SSHClient{
+			password: network.Password,
+		}
 		if err := bastion.Connect(network.Bastion); err != nil {
 			return errors.Wrap(err, "connecting to bastion failed")
 		}
@@ -70,8 +72,9 @@ func (sup *Stackup) Run(network *Network, envVars EnvList, commands ...*Command)
 
 			// SSH client.
 			remote := &SSHClient{
-				env:   env + `export SUP_HOST="` + host + `";`,
-				color: Colors[i%len(Colors)],
+				env:      env + `export SUP_HOST="` + host + `";`,
+				color:    Colors[i%len(Colors)],
+				password: network.Password,
 			}
 
 			if bastion != nil {

--- a/supfile.go
+++ b/supfile.go
@@ -28,6 +28,7 @@ type Network struct {
 	Env       EnvList  `yaml:"env"`
 	Inventory string   `yaml:"inventory"`
 	Hosts     []string `yaml:"hosts"`
+	Password  string   `yaml:"password"`
 	Bastion   string   `yaml:"bastion"` // Jump host for the environment
 }
 


### PR DESCRIPTION
A basic implementation of password based ssh authentication - I've been using this tool for a while, and it's great.  We have some environments that we can't use key-based authentication.

I know in issue #29 there were some concerns raised.  I think we need to let the end users decide to secure their Supfiles if they decide to place plaintext passwords in them.