### PR TITLE
Mark host to be asked for password

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -12,12 +12,14 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Client is a wrapper over the SSH connection/sessions.
 type SSHClient struct {
 	conn         *ssh.Client
 	sess         *ssh.Session
+	ask          bool
 	user         string
 	host         string
 	remoteStdin  io.WriteCloser
@@ -51,6 +53,11 @@ func (c *SSHClient) parseHost(host string) error {
 
 	if at := strings.Index(c.host, "@"); at != -1 {
 		c.user = c.host[:at]
+		c.ask = false
+		if ask := strings.Index(c.user, "ask:"); ask == 0 {
+			c.user = c.user[4:]
+			c.ask = true
+		}
 		c.host = c.host[at+1:]
 	}
 
@@ -133,11 +140,24 @@ func (c *SSHClient) ConnectWith(host string, dialer SSHDialFunc) error {
 		return err
 	}
 
-	config := &ssh.ClientConfig{
-		User: c.user,
-		Auth: []ssh.AuthMethod{
-			authMethod,
-		},
+	var config *ssh.ClientConfig
+	if c.ask {
+		fmt.Print("Enter Password for " + c.user + "@" + c.host + ": ")
+		pass, _ := terminal.ReadPassword(0)
+		fmt.Println("")
+		config = &ssh.ClientConfig{
+			User: c.user,
+			Auth: []ssh.AuthMethod{
+				ssh.Password(string(pass)),
+			},
+		}
+	} else {
+		config = &ssh.ClientConfig{
+			User: c.user,
+			Auth: []ssh.AuthMethod{
+				authMethod,
+			},
+		}
 	}
 
 	c.conn, err = dialer("tcp", c.host, config)


### PR DESCRIPTION
Ability to mark host with `ask:` marker and will be prompted to enter password for that host.

```yaml
# Supfile

networks:
    production:
        hosts:
            - ask:user@1.1.1.1:22
```
It will prompt: `Enter Password for user@1.1.1.1:22:`