### PR TITLE
Print usage items (networks/targets/commands) in order

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -67,9 +68,14 @@ func networkUsage(conf *sup.Supfile) {
 
 	// Print available networks/hosts.
 	fmt.Fprintln(w, "Networks:\t")
-	for name, network := range conf.Networks {
+	names := make([]string, 0)
+	for name := range conf.Networks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
 		fmt.Fprintf(w, "- %v\n", name)
-		for _, host := range network.Hosts {
+		for _, host := range conf.Networks[name].Hosts {
 			fmt.Fprintf(w, "\t- %v\n", host)
 		}
 	}
@@ -83,13 +89,23 @@ func cmdUsage(conf *sup.Supfile) {
 
 	// Print available targets/commands.
 	fmt.Fprintln(w, "Targets:\t")
-	for name, commands := range conf.Targets {
-		fmt.Fprintf(w, "- %v\t%v\n", name, strings.Join(commands, " "))
+	names := make([]string, 0)
+	for name := range conf.Targets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintf(w, "- %v\t%v\n", name, strings.Join(conf.Targets[name], " "))
 	}
 	fmt.Fprintln(w, "\t")
 	fmt.Fprintln(w, "Commands:\t")
-	for name, cmd := range conf.Commands {
-		fmt.Fprintf(w, "- %v\t%v\n", name, cmd.Desc)
+	names = names[:0]
+	for name := range conf.Commands {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintf(w, "- %v\t%v\n", name, conf.Commands[name].Desc)
 	}
 	fmt.Fprintln(w)
 }

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -68,14 +68,9 @@ func networkUsage(conf *sup.Supfile) {
 
 	// Print available networks/hosts.
 	fmt.Fprintln(w, "Networks:\t")
-	names := make([]string, 0)
-	for name := range conf.Networks {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		fmt.Fprintf(w, "- %v\n", name)
-		for _, host := range conf.Networks[name].Hosts {
+	for _, network := range conf.Networks {
+		fmt.Fprintf(w, "- %v\n", network.Name)
+		for _, host := range network.Hosts {
 			fmt.Fprintf(w, "\t- %v\n", host)
 		}
 	}
@@ -122,7 +117,14 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 	}
 
 	// Does the <network> exist?
-	network, ok := conf.Networks[args[0]]
+	var network sup.Network
+	var ok bool
+	for _, net := range conf.Networks {
+		if net.Name == args[0] {
+			network, ok = net.Network, true
+			break
+		}
+	}
 	if !ok {
 		networkUsage(conf)
 		return nil, nil, ErrUnknownNetwork


### PR DESCRIPTION
When printing usage, `networkUsage` and `cmdUsage` iterate the maps directly, which may lead to different outputs (not in a same order) every time.

![1485307471](https://cloud.githubusercontent.com/assets/6850317/22275201/ed16f4b0-e2e5-11e6-8368-c5a30d16e814.png)

This PR just sorts the names of available networks/targets/commands before iterating and printing them so that they are listed by alphabetical order.
