### PR TITLE
Fix of ssh-add bash snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ if you see something like `The agent has no identities.` it means that you need 
 in order to do that, run the following command
 
 ```bash
-ssh-add -K ~/.ssh/id_rsa
+ssh-add -k ~/.ssh/id_rsa
 ```
 
 you should now be able to use sup with your ssh key.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ if you see something like `The agent has no identities.` it means that you need 
 in order to do that, run the following command
 
 ```bash
-ssh-add -k ~/.ssh/id_rsa
+ssh-add ~/.ssh/id_rsa
 ```
 
 you should now be able to use sup with your ssh key.


### PR DESCRIPTION
ssh-add doesn't have an uppercase K as option. It needs to be a lowercase k.

This needs to be checked, so in case there are differences between ssh-add versions or distributions. It is a lowercase k on Ubuntu 14.04.