### PR TITLE
Search for identity files using id_*.pub wildcard

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -12,6 +12,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"path/filepath"
 )
 
 // Client is a wrapper over the SSH connection/sessions.
@@ -90,12 +91,10 @@ func initAuthMethod() {
 	}
 
 	// Try to read user's SSH private keys form the standard paths.
-	files := []string{
-		os.Getenv("HOME") + "/.ssh/id_rsa",
-		os.Getenv("HOME") + "/.ssh/id_dsa",
-	}
-	for _, file := range files {
-		data, err := ioutil.ReadFile(file)
+	pubKeyFiles, _ := filepath.Glob(os.Getenv("HOME") + "/.ssh/id_*.pub")
+	for _, pubKey := range pubKeyFiles {
+		privkey := pubKey[:len(pubKey) - len(".pub")]
+		data, err := ioutil.ReadFile(privkey)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Instead of using hard-coded "id_rsa" and "id_dsa" filenames.

Besides the use of ecdsa and edsa keys this also allows the use of
other network-specific keys if they follow this naming convention.

Refs #86.