### PR TITLE
128 identity file

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -303,12 +303,12 @@ func main() {
 		}
 
 		// check network.Hosts for match
-		for _, host := range network.Hosts {
+		for i, host := range network.Hosts {
 			conf, found := confMap[host]
 			if found {
 				network.User = conf.User
 				network.IdentityFile = resolvePath(conf.IdentityFile)
-				network.Hosts = []string{fmt.Sprintf("%s:%d", conf.HostName, conf.Port)}
+				network.Hosts[i] = fmt.Sprintf("%s:%d", conf.HostName, conf.Port)
 			}
 		}
 	}

--- a/sup.go
+++ b/sup.go
@@ -70,9 +70,10 @@ func (sup *Stackup) Run(network *Network, envVars EnvList, commands ...*Command)
 
 			// SSH client.
 			remote := &SSHClient{
-				env:   env + `export SUP_HOST="` + host + `";`,
-				user:  network.User,
-				color: Colors[i%len(Colors)],
+				env:          env + `export SUP_HOST="` + host + `";`,
+				user:         network.User,
+				color:        Colors[i%len(Colors)],
+				identityFile: network.IdentityFile,
 			}
 
 			if bastion != nil {


### PR DESCRIPTION
This MR addresses the first point from https://github.com/pressly/sup/issues/128 and uses host defined SSH config for each host in a network, not just overwriting all of them.