### PR TITLE
Test sup command

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -71,141 +71,6 @@ func init() {
 
 }
 
-func networkUsage(conf *sup.Supfile) {
-	w := &tabwriter.Writer{}
-	w.Init(os.Stderr, 4, 4, 2, ' ', 0)
-	defer w.Flush()
-
-	// Print available networks/hosts.
-	fmt.Fprintln(w, "Networks:\t")
-	for _, name := range conf.Networks.Names {
-		fmt.Fprintf(w, "- %v\n", name)
-		network, _ := conf.Networks.Get(name)
-		for _, host := range network.Hosts {
-			fmt.Fprintf(w, "\t- %v\n", host)
-		}
-	}
-	fmt.Fprintln(w)
-}
-
-func cmdUsage(conf *sup.Supfile) {
-	w := &tabwriter.Writer{}
-	w.Init(os.Stderr, 4, 4, 2, ' ', 0)
-	defer w.Flush()
-
-	// Print available targets/commands.
-	fmt.Fprintln(w, "Targets:\t")
-	for _, name := range conf.Targets.Names {
-		cmds, _ := conf.Targets.Get(name)
-		fmt.Fprintf(w, "- %v\t%v\n", name, strings.Join(cmds, " "))
-	}
-	fmt.Fprintln(w, "\t")
-	fmt.Fprintln(w, "Commands:\t")
-	for _, name := range conf.Commands.Names {
-		cmd, _ := conf.Commands.Get(name)
-		fmt.Fprintf(w, "- %v\t%v\n", name, cmd.Desc)
-	}
-	fmt.Fprintln(w)
-}
-
-// parseArgs parses args and returns network and commands to be run.
-// On error, it prints usage and exits.
-func parseArgs(args []string, conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
-	var commands []*sup.Command
-
-	if len(args) < 1 {
-		networkUsage(conf)
-		return nil, nil, ErrUsage
-	}
-
-	// Does the <network> exist?
-	network, ok := conf.Networks.Get(args[0])
-	if !ok {
-		networkUsage(conf)
-		return nil, nil, ErrUnknownNetwork
-	}
-
-	hosts, err := network.ParseInventory()
-	if err != nil {
-		return nil, nil, err
-	}
-	network.Hosts = append(network.Hosts, hosts...)
-
-	// Does the <network> have at least one host?
-	if len(network.Hosts) == 0 {
-		networkUsage(conf)
-		return nil, nil, ErrNetworkNoHosts
-	}
-
-	// Check for the second argument
-	if len(args) < 2 {
-		cmdUsage(conf)
-		return nil, nil, ErrUsage
-	}
-
-	// In case of the network.Env needs an initialization
-	if network.Env == nil {
-		network.Env = make(sup.EnvList, 0)
-	}
-
-	// Add default env variable with current network
-	network.Env.Set("SUP_NETWORK", args[0])
-
-	// Add default nonce
-	network.Env.Set("SUP_TIME", time.Now().UTC().Format(time.RFC3339))
-	if os.Getenv("SUP_TIME") != "" {
-		network.Env.Set("SUP_TIME", os.Getenv("SUP_TIME"))
-	}
-
-	// Add user
-	if os.Getenv("SUP_USER") != "" {
-		network.Env.Set("SUP_USER", os.Getenv("SUP_USER"))
-	} else {
-		network.Env.Set("SUP_USER", os.Getenv("USER"))
-	}
-
-	for _, cmd := range args[1:] {
-		// Target?
-		target, isTarget := conf.Targets.Get(cmd)
-		if isTarget {
-			// Loop over target's commands.
-			for _, cmd := range target {
-				command, isCommand := conf.Commands.Get(cmd)
-				if !isCommand {
-					cmdUsage(conf)
-					return nil, nil, fmt.Errorf("%v: %v", ErrCmd, cmd)
-				}
-				command.Name = cmd
-				commands = append(commands, &command)
-			}
-		}
-
-		// Command?
-		command, isCommand := conf.Commands.Get(cmd)
-		if isCommand {
-			command.Name = cmd
-			commands = append(commands, &command)
-		}
-
-		if !isTarget && !isCommand {
-			cmdUsage(conf)
-			return nil, nil, fmt.Errorf("%v: %v", ErrCmd, cmd)
-		}
-	}
-
-	return &network, commands, nil
-}
-
-func resolvePath(path string) string {
-	if path[:2] == "~/" {
-		usr, err := user.Current()
-		if err == nil {
-			path = filepath.Join(usr.HomeDir, path[2:])
-		}
-	}
-	return path
-}
-
 func main() {
 	flag.Parse()
 
@@ -238,6 +103,16 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func resolvePath(path string) string {
+	if path[:2] == "~/" {
+		usr, err := user.Current()
+		if err == nil {
+			path = filepath.Join(usr.HomeDir, path[2:])
+		}
+	}
+	return path
 }
 
 func runSupfile(options options, args []string, data []byte) error {
@@ -354,5 +229,129 @@ func runSupfile(options options, args []string, data []byte) error {
 
 	// Run all the commands in the given network.
 	return app.Run(network, vars, commands...)
+}
 
+// parseArgs parses args and returns network and commands to be run.
+// On error, it prints usage and exits.
+func parseArgs(args []string, conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
+	var commands []*sup.Command
+
+	if len(args) < 1 {
+		networkUsage(conf)
+		return nil, nil, ErrUsage
+	}
+
+	// Does the <network> exist?
+	network, ok := conf.Networks.Get(args[0])
+	if !ok {
+		networkUsage(conf)
+		return nil, nil, ErrUnknownNetwork
+	}
+
+	hosts, err := network.ParseInventory()
+	if err != nil {
+		return nil, nil, err
+	}
+	network.Hosts = append(network.Hosts, hosts...)
+
+	// Does the <network> have at least one host?
+	if len(network.Hosts) == 0 {
+		networkUsage(conf)
+		return nil, nil, ErrNetworkNoHosts
+	}
+
+	// Check for the second argument
+	if len(args) < 2 {
+		cmdUsage(conf)
+		return nil, nil, ErrUsage
+	}
+
+	// In case of the network.Env needs an initialization
+	if network.Env == nil {
+		network.Env = make(sup.EnvList, 0)
+	}
+
+	// Add default env variable with current network
+	network.Env.Set("SUP_NETWORK", args[0])
+
+	// Add default nonce
+	network.Env.Set("SUP_TIME", time.Now().UTC().Format(time.RFC3339))
+	if os.Getenv("SUP_TIME") != "" {
+		network.Env.Set("SUP_TIME", os.Getenv("SUP_TIME"))
+	}
+
+	// Add user
+	if os.Getenv("SUP_USER") != "" {
+		network.Env.Set("SUP_USER", os.Getenv("SUP_USER"))
+	} else {
+		network.Env.Set("SUP_USER", os.Getenv("USER"))
+	}
+
+	for _, cmd := range args[1:] {
+		// Target?
+		target, isTarget := conf.Targets.Get(cmd)
+		if isTarget {
+			// Loop over target's commands.
+			for _, cmd := range target {
+				command, isCommand := conf.Commands.Get(cmd)
+				if !isCommand {
+					cmdUsage(conf)
+					return nil, nil, fmt.Errorf("%v: %v", ErrCmd, cmd)
+				}
+				command.Name = cmd
+				commands = append(commands, &command)
+			}
+		}
+
+		// Command?
+		command, isCommand := conf.Commands.Get(cmd)
+		if isCommand {
+			command.Name = cmd
+			commands = append(commands, &command)
+		}
+
+		if !isTarget && !isCommand {
+			cmdUsage(conf)
+			return nil, nil, fmt.Errorf("%v: %v", ErrCmd, cmd)
+		}
+	}
+
+	return &network, commands, nil
+}
+
+func networkUsage(conf *sup.Supfile) {
+	w := &tabwriter.Writer{}
+	w.Init(os.Stderr, 4, 4, 2, ' ', 0)
+	defer w.Flush()
+
+	// Print available networks/hosts.
+	fmt.Fprintln(w, "Networks:\t")
+	for _, name := range conf.Networks.Names {
+		fmt.Fprintf(w, "- %v\n", name)
+		network, _ := conf.Networks.Get(name)
+		for _, host := range network.Hosts {
+			fmt.Fprintf(w, "\t- %v\n", host)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+func cmdUsage(conf *sup.Supfile) {
+	w := &tabwriter.Writer{}
+	w.Init(os.Stderr, 4, 4, 2, ' ', 0)
+	defer w.Flush()
+
+	// Print available targets/commands.
+	fmt.Fprintln(w, "Targets:\t")
+	for _, name := range conf.Targets.Names {
+		cmds, _ := conf.Targets.Get(name)
+		fmt.Fprintf(w, "- %v\t%v\n", name, strings.Join(cmds, " "))
+	}
+	fmt.Fprintln(w, "\t")
+	fmt.Fprintln(w, "Commands:\t")
+	for _, name := range conf.Commands.Names {
+		cmd, _ := conf.Commands.Get(name)
+		fmt.Fprintf(w, "- %v\t%v\n", name, cmd.Desc)
+	}
+	fmt.Fprintln(w)
 }

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -303,12 +303,12 @@ func main() {
 		}
 
 		// check network.Hosts for match
-		for _, host := range network.Hosts {
+		for i, host := range network.Hosts {
 			conf, found := confMap[host]
 			if found {
 				network.User = conf.User
 				network.IdentityFile = resolvePath(conf.IdentityFile)
-				network.Hosts = []string{fmt.Sprintf("%s:%d", conf.HostName, conf.Port)}
+				network.Hosts[i] = fmt.Sprintf("%s:%d", conf.HostName, conf.Port)
 			}
 		}
 	}

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -125,7 +125,7 @@ func runSupfile(options options, args []string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(network.Hosts)
+
 	// --only flag filters hosts
 	if options.onlyHosts != "" {
 		expr, err := regexp.CompilePOSIX(options.onlyHosts)
@@ -153,7 +153,6 @@ func runSupfile(options options, args []string, data []byte) error {
 
 		var hosts []string
 		for _, host := range network.Hosts {
-			fmt.Println(host)
 			if !expr.MatchString(host) {
 				hosts = append(hosts, host)
 			}

--- a/cmd/sup/main_test.go
+++ b/cmd/sup/main_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/mikkeloscar/sshconfig"
+	"github.com/pressly/sup"
+)
+
+func TestSSH(t *testing.T) {
+	outputs, err := setupMockEnv(sshConfigFilename, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	flag.CommandLine = flag.NewFlagSet("test", flag.ExitOnError)
+	flag.CommandLine.Parse([]string{"local", "t"})
+
+	input := `
+---
+version: 0.4
+
+networks:
+  local:
+    hosts:
+    - server0
+    - server1
+    - server2
+
+commands:
+  test:
+    run: echo "Hey over there"
+  test2:
+    run: echo "Hey again"
+
+targets:
+  t:
+  - test
+  - test2
+`
+	conf, err := sup.NewSupfile([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	network, commands, err := parseArgs(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	confHosts, err := sshconfig.ParseSSHConfig(sshConfigFilename)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// flatten Host -> *SSHHost, not the prettiest
+	// but will do
+	confMap := map[string]*sshconfig.SSHHost{}
+	for _, conf := range confHosts {
+		for _, host := range conf.Host {
+			confMap[host] = conf
+		}
+	}
+
+	// check network.Hosts for match
+	for i, host := range network.Hosts {
+		conf, found := confMap[host]
+		if found {
+			network.User = conf.User
+			network.IdentityFile = resolvePath(conf.IdentityFile)
+			network.Hosts[i] = fmt.Sprintf("%s:%d", conf.HostName, conf.Port)
+		}
+	}
+
+	var vars sup.EnvList
+	for _, val := range append(conf.Env, network.Env...) {
+		vars.Set(val.Key, val.Value)
+	}
+	if err := vars.ResolveValues(); err != nil {
+		t.Fatal(err)
+	}
+
+	app, err := sup.New(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = app.Run(network, vars, commands...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, output := range outputs {
+		t.Log(i, output.String())
+	}
+}

--- a/cmd/sup/main_test.go
+++ b/cmd/sup/main_test.go
@@ -27,7 +27,6 @@ networks:
   local:
     hosts:
     - server0
-    - server1
     - server2
 
 commands:
@@ -93,7 +92,10 @@ targets:
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i, output := range outputs {
-		t.Log(i, output.String())
-	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 2)
+	m.expectNoActivityOnServers(1)
+	m.expectExportOnActiveServers(`SUP_NETWORK="local"`)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
 }

--- a/cmd/sup/main_test.go
+++ b/cmd/sup/main_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 func TestSSH(t *testing.T) {
-	outputs, err := setupMockEnv(sshConfigFilename, 3)
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 3)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer cleanup()
 
 	flag.CommandLine = flag.NewFlagSet("test", flag.ExitOnError)
 	flag.CommandLine.Parse([]string{"local", "t"})
@@ -50,7 +51,7 @@ targets:
 		t.Fatal(err)
 	}
 
-	confHosts, err := sshconfig.ParseSSHConfig(sshConfigFilename)
+	confHosts, err := sshconfig.ParseSSHConfig(sshConfigPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/sup/main_test.go
+++ b/cmd/sup/main_test.go
@@ -1,10 +1,180 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
 	"testing"
+	"time"
 )
 
-func TestSSH(t *testing.T) {
+func TestInvalidYaml(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+efewf we
+we	kp	re
+`
+	if err := runSupfile(options{}, []string{}, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	}
+}
+
+func TestNoNetworkSpecified(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	if err := runSupfile(options{}, []string{}, []byte(input)); err != ErrUsage {
+		t.Fatal(err)
+	}
+}
+
+func TestUnknownNetwork(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	if err := runSupfile(options{}, []string{"production"}, []byte(input)); err != ErrUnknownNetwork {
+		t.Fatal(err)
+	}
+}
+
+func TestNoHosts(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	if err := runSupfile(options{}, []string{"staging"}, []byte(input)); err != ErrNetworkNoHosts {
+		t.Fatal(err)
+	}
+}
+
+func TestNoCommand(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	if err := runSupfile(options{}, []string{"staging"}, []byte(input)); err != ErrUsage {
+		t.Fatal(err)
+	}
+}
+
+func TestNonexistentCommandOrTarget(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+  step2:
+    run: echo "Hey again"
+
+targets:
+  walk:
+  - step1
+  - step2
+`
+	if err := runSupfile(options{}, []string{"staging", "step5"}, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	} else if !strings.Contains(err.Error(), ErrCmd.Error()) {
+		t.Fatalf("Expected `%v` error, got `%v`", ErrCmd, err)
+	}
+}
+
+func TestTargetReferencingNonexistentCommand(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+  step2:
+    run: echo "Hey again"
+
+targets:
+  walk:
+  - step1
+  - step2
+  - step3
+`
+	if err := runSupfile(options{}, []string{"staging", "walk"}, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	} else if !strings.Contains(err.Error(), ErrCmd.Error()) {
+		t.Fatalf("Expected `%v` error, got `%v`", ErrCmd, err)
+	}
+}
+
+func TestOneCommand(t *testing.T) {
+	t.Parallel()
+
 	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 3)
 	if err != nil {
 		t.Fatal(err)
@@ -16,30 +186,721 @@ func TestSSH(t *testing.T) {
 version: 0.4
 
 networks:
-  local:
+  staging:
     hosts:
     - server0
     - server2
 
 commands:
-  test:
+  step1:
     run: echo "Hey over there"
-  test2:
-    run: echo "Hey again"
-
-targets:
-  t:
-  - test
-  - test2
 `
-	args := []string{"--sshconfig", sshConfigPath, "local", "t"}
-	if err := runSupfile(args, []byte(input)); err != nil {
+	options := options{
+		sshConfig: sshConfigPath,
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
 		t.Fatal(err)
 	}
 
 	m := newMatcher(outputs, t)
 	m.expectActivityOnServers(0, 2)
 	m.expectNoActivityOnServers(1)
-	m.expectExportOnActiveServers(`SUP_NETWORK="local"`)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+}
+
+func TestSequenceOfCommands(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+  step2:
+    run: echo "Hey again"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+	}
+	args := []string{"staging", "step1", "step2"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 2)
+	m.expectNoActivityOnServers(1)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+	m.expectCommandOnActiveServers(`echo "Hey again"`)
+}
+
+func TestTarget(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+  step2:
+    run: echo "Hey again"
+
+targets:
+  walk:
+  - step1
+  - step2
+`
+	options := options{
+		sshConfig: sshConfigPath,
+	}
+	args := []string{"staging", "walk"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 2)
+	m.expectNoActivityOnServers(1)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+	m.expectCommandOnActiveServers(`echo "Hey again"`)
+}
+
+func TestOnlyHosts(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+		onlyHosts: "server2",
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(2)
+	m.expectNoActivityOnServers(0, 1)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+}
+
+func TestOnlyHostsEmpty(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		onlyHosts: "server42",
+	}
+	if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	} else if !strings.Contains(err.Error(), "no hosts match") {
+		t.Fatalf("Expected a different error, got `%v`", err)
+	}
+}
+
+func TestOnlyHostsInvalid(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		onlyHosts: "server(",
+	}
+	if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	} else if !strings.Contains(err.Error(), "error parsing regexp") {
+		t.Fatalf("Expected a different error, got `%v`", err)
+	}
+}
+
+func TestExceptHosts(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig:   sshConfigPath,
+		exceptHosts: "server(1|2)",
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0)
+	m.expectNoActivityOnServers(1, 2)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+}
+
+func TestExceptHostsEmpty(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		exceptHosts: "server",
+	}
+	if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	} else if !strings.Contains(err.Error(), "no hosts left") {
+		t.Fatalf("Expected a different error, got `%v`", err)
+	}
+}
+
+func TestExceptHostsInvalid(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+    - server2
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		exceptHosts: "server(",
+	}
+	if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	} else if !strings.Contains(err.Error(), "error parsing regexp") {
+		t.Fatalf("Expected a different error, got `%v`", err)
+	}
+}
+
+func TestInventory(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    inventory: array=( 0 2 ); for i in "${array[@]}"; do printf "server$i\n\n# comment\n"; done
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 2)
+	m.expectNoActivityOnServers(1)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+}
+
+func TestFailedInventory(t *testing.T) {
+	t.Parallel()
+
+	input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    inventory: this won't compile
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options{}, args, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	}
+}
+
+func TestSupVariables(t *testing.T) {
+	t.Parallel()
+
+	// these tests need to run in order because they mess with env vars
+	t.Run("default", func(t *testing.T) {
+		if time.Now().Hour() == 23 && time.Now().Minute() == 59 {
+			t.Skip("Skipping test")
+		}
+
+		outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+
+		input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+		options := options{
+			sshConfig: sshConfigPath,
+		}
+		if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err != nil {
+			t.Fatal(err)
+		}
+		currentUser, err := user.Current()
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := newMatcher(outputs, t)
+		m.expectActivityOnServers(0, 1)
+		m.expectExportOnActiveServers(`SUP_NETWORK="staging"`)
+		m.expectExportOnActiveServers(`SUP_ENV=""`)
+		m.expectExportOnActiveServers(fmt.Sprintf(`SUP_USER="%s"`, currentUser.Name))
+		m.expectExportRegexpOnActiveServers(`SUP_HOST="localhost:\d+"`)
+	})
+
+	t.Run("default SUP_TIME", func(t *testing.T) {
+
+		if time.Now().Hour() == 23 && time.Now().Minute() == 59 {
+			t.Skip("Skipping SUP_TIME test because it might fail around midnight")
+		}
+
+		outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+
+		input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+		options := options{
+			sshConfig: sshConfigPath,
+		}
+		if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err != nil {
+			t.Fatal(err)
+		}
+		m := newMatcher(outputs, t)
+		m.expectActivityOnServers(0, 1)
+		m.expectExportRegexpOnActiveServers(
+			fmt.Sprintf(
+				`SUP_TIME="%4d-%02d-%02dT[0-2][0-9]:[0-5][0-9]:[0-5][0-9]Z"`,
+				time.Now().Year(),
+				time.Now().Month(),
+				time.Now().Day(),
+			),
+		)
+	})
+
+	t.Run("SUP_TIME env var set", func(t *testing.T) {
+		outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+
+		input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+		os.Setenv("SUP_TIME", "now")
+		options := options{
+			sshConfig: sshConfigPath,
+		}
+		if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err != nil {
+			t.Fatal(err)
+		}
+		m := newMatcher(outputs, t)
+		m.expectActivityOnServers(0, 1)
+		m.expectExportOnActiveServers(`SUP_TIME="now"`)
+	})
+
+	t.Run("SUP_USER env var set", func(t *testing.T) {
+		outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+
+		input := `
+---
+version: 0.4
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+		os.Setenv("SUP_USER", "sup_rules")
+		options := options{
+			sshConfig: sshConfigPath,
+		}
+		if err := runSupfile(options, []string{"staging", "step1"}, []byte(input)); err != nil {
+			t.Fatal(err)
+		}
+		m := newMatcher(outputs, t)
+		m.expectActivityOnServers(0, 1)
+		m.expectExportOnActiveServers(`SUP_USER="sup_rules"`)
+	})
+}
+
+func TestInvalidVars(t *testing.T) {
+	t.Parallel()
+
+	_, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+env:
+  TODAYS_SPECIAL: this won't compile
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err == nil {
+		t.Fatal("Expected an error")
+	}
+
+}
+
+func TestEnvLevelVars(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+env:
+  TODAYS_SPECIAL: "dog milk"
+
+networks:
+  staging:
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 1)
+	m.expectExportOnActiveServers(`TODAYS_SPECIAL="dog milk"`)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+}
+
+func TestNetworkLevelVars(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+env:
+  TODAYS_SPECIAL: "dog milk"
+
+networks:
+  staging:
+    env:
+      TODAYS_SPECIAL: "Trout a la Crème"
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 1)
+	m.expectExportOnActiveServers(`TODAYS_SPECIAL="Trout a la Crème"`)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+}
+
+func TestCommandLineLevelVars(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+env:
+  TODAYS_SPECIAL: "dog milk"
+
+networks:
+  staging:
+    env:
+      TODAYS_SPECIAL: "Trout a la Crème"
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+		envVars:   []string{"IM_HERE", "TODAYS_SPECIAL=Gazpacho"},
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 1)
+	m.expectExportOnActiveServers(`IM_HERE=""`)
+	m.expectExportOnActiveServers(`TODAYS_SPECIAL="Gazpacho"`)
+	m.expectExportOnActiveServers(`SUP_ENV="-e TODAYS_SPECIAL="Gazpacho""`)
+	m.expectCommandOnActiveServers(`echo "Hey over there"`)
+}
+
+func TestEmptyCommandLineLevelVars(t *testing.T) {
+	t.Parallel()
+
+	outputs, sshConfigPath, cleanup, err := setupMockEnv("ssh_config", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	input := `
+---
+version: 0.4
+
+env:
+  TODAYS_SPECIAL: "dog milk"
+
+networks:
+  staging:
+    env:
+      TODAYS_SPECIAL: "Trout a la Crème"
+    hosts:
+    - server0
+    - server1
+
+commands:
+  step1:
+    run: echo "Hey over there"
+`
+	options := options{
+		sshConfig: sshConfigPath,
+		envVars:   []string{""},
+	}
+	args := []string{"staging", "step1"}
+	if err := runSupfile(options, args, []byte(input)); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newMatcher(outputs, t)
+	m.expectActivityOnServers(0, 1)
+	m.expectExportOnActiveServers(`TODAYS_SPECIAL="Trout a la Crème"`)
+	m.expectExportOnActiveServers(`SUP_ENV=""`)
 	m.expectCommandOnActiveServers(`echo "Hey over there"`)
 }

--- a/cmd/sup/matchers_test.go
+++ b/cmd/sup/matchers_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// matcher defines high level expectations over a collection of output buffers
+type matcher struct {
+	outputs       []bytes.Buffer
+	t             *testing.T
+	activeServers []int
+}
+
+func newMatcher(outputs []bytes.Buffer, t *testing.T) matcher {
+	return matcher{
+		outputs: outputs,
+		t:       t,
+	}
+}
+
+func (m *matcher) expectActivityOnServers(servers ...int) {
+	m.activeServers = servers
+	m.onEachActiveServer(func(server int, output string) {
+		if len(output) == 0 {
+			m.t.Errorf("expected activity on server #%d", server)
+		}
+	})
+}
+func (m *matcher) expectNoActivityOnServers(servers ...int) {
+	for _, server := range servers {
+		if server >= len(m.outputs) || server < 0 {
+			m.t.Errorf("output from server #%d not provided", server)
+			return
+		}
+		output := m.outputs[server]
+		if output.Len() > 0 {
+			m.t.Errorf("expected no activity on server #%d:\n%s", server, output.String())
+		}
+	}
+}
+
+func (m matcher) expectExportOnActiveServers(export string) {
+	m.onEachActiveServer(func(server int, output string) {
+		for i, executed := range strings.Split(output, "\n") {
+			if !strings.Contains(executed, fmt.Sprintf("export %s;", export)) {
+				m.t.Errorf(
+					"command #%d on server #%d does not export `%s`:\n%s",
+					i,
+					server,
+					export,
+					executed,
+				)
+			}
+		}
+	})
+}
+
+func (m matcher) expectCommandOnActiveServers(command string) {
+	m.onEachActiveServer(func(server int, output string) {
+		for _, executed := range strings.Split(output, "\n") {
+			if strings.HasSuffix(executed, fmt.Sprintf(";%s", command)) {
+				return
+			}
+		}
+		m.t.Errorf("no command on server #%d executed `%s`", server, command)
+	})
+}
+
+func (m matcher) onEachActiveServer(expectation func(server int, output string)) {
+	for _, server := range m.activeServers {
+		if server >= len(m.outputs) || server < 0 {
+			m.t.Errorf("output from server #%d not provided", server)
+			return
+		}
+
+		output := m.outputs[server]
+		expectation(server, strings.TrimSpace(output.String()))
+	}
+}

--- a/cmd/sup/matchers_test.go
+++ b/cmd/sup/matchers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -46,6 +47,25 @@ func (m matcher) expectExportOnActiveServers(export string) {
 	m.onEachActiveServer(func(server int, output string) {
 		for i, executed := range strings.Split(output, "\n") {
 			if !strings.Contains(executed, fmt.Sprintf("export %s;", export)) {
+				m.t.Errorf(
+					"command #%d on server #%d does not export `%s`:\n%s",
+					i,
+					server,
+					export,
+					executed,
+				)
+			}
+		}
+	})
+}
+func (m matcher) expectExportRegexpOnActiveServers(export string) {
+	m.onEachActiveServer(func(server int, output string) {
+		for i, executed := range strings.Split(output, "\n") {
+			re, err := regexp.Compile(fmt.Sprintf("export %s;", export))
+			if err != nil {
+				m.t.Fatal(err)
+			}
+			if !re.MatchString(executed) {
 				m.t.Errorf(
 					"command #%d on server #%d does not export `%s`:\n%s",
 					i,

--- a/cmd/sup/mock_server_test.go
+++ b/cmd/sup/mock_server_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+)
+
+const privateKeyFilename = "gotest_private_key"
+const authorizedKeysFilename = "authorized_keys"
+const sshConfigFilename = "ssh_config"
+
+// setupMockEnv prepares testing environment, it
+//
+// - generates RSA key pair
+// 	- the private key is written into a file
+//  - fingerprint of the public key is written into a file as an authorized key
+// - spins up mock SSH servers with the same authorized key
+// - writes an SSH config file with entries for all servers
+func setupMockEnv(sshConfigFilename string, count int) ([]bytes.Buffer, error) {
+	if err := generateKeyPair(privateKeyFilename, authorizedKeysFilename); err != nil {
+		return nil, err
+	}
+
+	outputs := make([]bytes.Buffer, count)
+	addresses := make([]string, count)
+	for i := 0; i < count; i++ {
+		runTestServer(authorizedKeysFilename, &addresses[i], &outputs[i])
+	}
+
+	if err := writeSSHConfigFile(privateKeyFilename, sshConfigFilename, addresses); err != nil {
+		return nil, err
+	}
+	return outputs, nil
+}
+
+// generateKeyPair generates a pair of keys, the private key is written into
+// a file and the fingerprint of the public key into authorized_keys file for
+// the server to use
+func generateKeyPair(privateKeyFilename, authorizedKeysFilename string) error {
+	privateKey, err := generatePrivateRSAKey()
+	if err != nil {
+		return err
+	}
+	if err := writePrivateKeyToFile(privateKey, privateKeyFilename); err != nil {
+		return err
+	}
+
+	publicKey := privateKey.PublicKey
+	pub, err := ssh.NewPublicKey(&publicKey)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(authorizedKeysFilename, ssh.MarshalAuthorizedKey(pub), os.ModePerm)
+}
+
+func generatePrivateRSAKey() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, 2014)
+}
+
+func writePrivateKeyToFile(privateKey *rsa.PrivateKey, filename string) error {
+	privateKeyBlock := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	return ioutil.WriteFile(
+		filename,
+		pem.EncodeToMemory(&privateKeyBlock),
+		os.ModePerm,
+	)
+}
+
+func runTestServer(authorizedKeysFilename string, addr *string, out io.Writer) error {
+	authorizedKeysMap, err := loadAuthorizedKeys(authorizedKeysFilename)
+	if err != nil {
+		return err
+	}
+
+	config, err := buildServerConfig(authorizedKeysMap)
+	if err != nil {
+		return err
+	}
+
+	listener, err := net.Listen("tcp", "localhost:")
+	if err != nil {
+		return errors.Wrap(err, "failed to listen for connection")
+	}
+	*addr = listener.Addr().String()
+
+	go sshListen(config, listener, out)
+
+	return nil
+}
+
+func buildServerConfig(authorizedKeysMap map[string]bool) (*ssh.ServerConfig, error) {
+	// An SSH server is represented by a ServerConfig, which holds
+	// certificate details and handles authentication of ServerConns.
+	config := &ssh.ServerConfig{
+		// Remove to disable public key auth.
+		PublicKeyCallback: func(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
+			if authorizedKeysMap[string(pubKey.Marshal())] {
+				return &ssh.Permissions{
+					// Record the public key used for authentication.
+					Extensions: map[string]string{
+						"pubkey-fp": fingerprintSHA256(pubKey),
+					},
+				}, nil
+			}
+			return nil, fmt.Errorf("unknown public key for %q", c.User())
+		},
+	}
+
+	key, err := generatePrivateRSAKey()
+	if err != nil {
+		return nil, err
+	}
+
+	private, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	config.AddHostKey(private)
+	return config, nil
+}
+
+func sshListen(config *ssh.ServerConfig, listener net.Listener, out io.Writer) {
+	func() {
+		nConn, err := listener.Accept()
+		if err != nil {
+			panic(errors.Wrap(err, "failed to accept incoming connection"))
+		}
+
+		// Before use, a handshake must be performed on the incoming
+		// net.Conn.
+		_, chans, reqs, err := ssh.NewServerConn(nConn, config)
+		if err != nil {
+			panic(errors.Wrap(err, "failed to handshake"))
+		}
+
+		// The incoming Request channel must be serviced.
+		go ssh.DiscardRequests(reqs)
+
+		// Service the incoming Channel channel.
+		for newChannel := range chans {
+			// Channels have a type, depending on the application level
+			// protocol intended. In the case of a shell, the type is
+			// "session" and ServerShell may be used to present a simple
+			// terminal interface.
+			if newChannel.ChannelType() != "session" {
+				newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
+				continue
+			}
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				panic(errors.Wrap(err, "Could not accept channel"))
+			}
+
+			go func(in <-chan *ssh.Request) {
+				defer channel.Close()
+
+				for req := range in {
+					// reply to pty-req with success
+					if req.Type == "pty-req" {
+						req.Reply(true, []byte{})
+
+						// read exec command, write it to output and respond with success
+					} else if req.Type == "exec" {
+						type execMsg struct {
+							Command string
+						}
+						var payload execMsg
+						ssh.Unmarshal(req.Payload, &payload)
+						out.Write([]byte(payload.Command + "\n"))
+						req.Reply(true, nil)
+
+						channel.SendRequest("exit-status", false, []byte{0, 0, 0, 0})
+						if err := channel.Close(); err != nil {
+							panic(err)
+						}
+					}
+				}
+			}(requests)
+		}
+	}()
+}
+
+func fingerprintSHA256(pubKey ssh.PublicKey) string {
+	sha256sum := sha256.Sum256(pubKey.Marshal())
+	hash := base64.RawStdEncoding.EncodeToString(sha256sum[:])
+	return "SHA256:" + hash
+}
+
+func loadAuthorizedKeys(filename string) (map[string]bool, error) {
+	authorizedKeysBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load %sv", filename)
+	}
+	authorizedKeysMap := map[string]bool{}
+	for len(authorizedKeysBytes) > 0 {
+		pubKey, _, _, rest, err := ssh.ParseAuthorizedKey(authorizedKeysBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		authorizedKeysMap[string(pubKey.Marshal())] = true
+		authorizedKeysBytes = rest
+	}
+	return authorizedKeysMap, nil
+}
+
+// writes simple SSH config file for the given servers naming them server0,
+// server1 etc.
+func writeSSHConfigFile(privateKeyFilename, sshConfigFilename string, addresses []string) error {
+	type sshRecord struct {
+		Host             string
+		Port             string
+		IdentityFilename string
+	}
+	records := make([]sshRecord, len(addresses))
+	for i, addr := range addresses {
+		records[i].Host = fmt.Sprintf("server%d", i)
+		records[i].IdentityFilename = privateKeyFilename
+		records[i].Port = strings.Split(addr, ":")[1]
+	}
+
+	sshConfigTemplate := `
+{{range .Records}}
+Host {{.Host}}
+  HostName localhost
+  Port {{.Port}}
+  IdentityFile {{.IdentityFilename}}
+{{end}}
+`
+
+	tmpl := template.New("ssh_config")
+	tmpl, err := tmpl.Parse(sshConfigTemplate)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(sshConfigFilename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	data := struct {
+		Records []sshRecord
+	}{
+		Records: records,
+	}
+
+	if err := tmpl.Execute(file, data); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/sup/mock_server_test.go
+++ b/cmd/sup/mock_server_test.go
@@ -26,11 +26,11 @@ const sshConfigFilename = "ssh_config"
 
 // setupMockEnv prepares testing environment, it
 //
-// - generates RSA key pair
-// 	- the private key is written into a file
-//  - fingerprint of the public key is written into a file as an authorized key
+// - generates RSA key pair; the private key is written into a file,
+//   fingerprint of the public key is written into a file as an authorized key
 // - spins up mock SSH servers with the same authorized key
-// - writes an SSH config file with entries for all servers
+// - writes an SSH config file with entries for all servers, naming them
+//   server0, server1 etc.
 func setupMockEnv(sshConfigFilename string, count int) ([]bytes.Buffer, error) {
 	if err := generateKeyPair(privateKeyFilename, authorizedKeysFilename); err != nil {
 		return nil, err

--- a/cmd/sup/mock_server_test.go
+++ b/cmd/sup/mock_server_test.go
@@ -13,12 +13,12 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
-	"path"
 )
 
 // setupMockEnv prepares testing environment, it

--- a/sup.go
+++ b/sup.go
@@ -70,9 +70,10 @@ func (sup *Stackup) Run(network *Network, envVars EnvList, commands ...*Command)
 
 			// SSH client.
 			remote := &SSHClient{
-				env:   env + `export SUP_HOST="` + host + `";`,
-				user:  network.User,
-				color: Colors[i%len(Colors)],
+				env:          env + `export SUP_HOST="` + host + `";`,
+				user:         network.User,
+				color:        Colors[i%len(Colors)],
+				identityFile: network.IdentityFile,
 			}
 
 			if bastion != nil {

--- a/supfile.go
+++ b/supfile.go
@@ -255,7 +255,7 @@ func (e ErrUnsupportedSupfileVersion) Error() string {
 }
 
 // NewSupfile parses configuration file and returns Supfile or error.
-func NewSupfile(data []byte) (*Supfile, error) {
+func NewSupfile(errStream io.Writer, data []byte) (*Supfile, error) {
 	var conf Supfile
 
 	if err := yaml.Unmarshal(data, &conf); err != nil {
@@ -305,7 +305,7 @@ func NewSupfile(data []byte) (*Supfile, error) {
 			}
 		}
 		if warning != "" {
-			fmt.Fprintf(os.Stderr, warning)
+			fmt.Fprintf(errStream, warning)
 		}
 
 		fallthrough
@@ -321,13 +321,13 @@ func NewSupfile(data []byte) (*Supfile, error) {
 
 // ParseInventory runs the inventory command, if provided, and appends
 // the command's output lines to the manually defined list of hosts.
-func (n Network) ParseInventory() ([]string, error) {
+func (n Network) ParseInventory(errStream io.Writer) ([]string, error) {
 	if n.Inventory == "" {
 		return nil, nil
 	}
 
 	cmd := exec.Command("/bin/sh", "-c", n.Inventory)
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = errStream
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR builds on top of https://github.com/pressly/sup/pull/134. It adds tests for sup commad as a sanity check of the existing functionality. In order to accomplish it I had to adjust the code in few places:

1. I moved most of the code from `main` to `runSupfile` so that it can be run from tests
0. Most flags are parsed into a struct so that tests don't depend on global vars (and it's a struct instead of eight separate variables)
0. To keep the test output clean the error output stream is passed around explicitly and set to `ioutil.Discard` in tests
0. `SSHClient` got new fields so that I could remove the global variable `initAuthMethodOnce` preventing running the command multiple times (aka when running tests)

The tests which need to spin up mock SSH servers, capture the requests and always respond with success. I barely understand this part and it's put together from different examples around the web.

I'm doing this as a preparation for tackling https://github.com/pressly/sup/issues/130.