### PR TITLE
Parse CLI envs for Network

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -122,7 +122,7 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 		return nil, nil, ErrUnknownNetwork
 	}
 
-	// Parse CLI --env flag env vars, define $SUP_ENV and override values defined in Network env.
+	// Parse CLI --env flag env vars, override values defined in Network env.
 	for _, env := range envVars {
 		if len(env) == 0 {
 			continue

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -122,6 +122,21 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 		return nil, nil, ErrUnknownNetwork
 	}
 
+	// Parse CLI --env flag env vars, define $SUP_ENV and override values defined in Network env.
+	for _, env := range envVars {
+		if len(env) == 0 {
+			continue
+		}
+		i := strings.Index(env, "=")
+		if i < 0 {
+			if len(env) > 0 {
+				network.Env.Set(env, "")
+			}
+			continue
+		}
+		network.Env.Set(env[:i], env[i+1:])
+	}
+
 	hosts, err := network.ParseInventory()
 	if err != nil {
 		return nil, nil, err

--- a/supfile.go
+++ b/supfile.go
@@ -170,6 +170,14 @@ func (e EnvVar) AsExport() string {
 // but maintains order, enabling late variables to reference early variables.
 type EnvList []*EnvVar
 
+func (e EnvList) Slice() []string {
+	envs := make([]string, len(e))
+	for i, env := range e {
+		envs[i] = env.String()
+	}
+	return envs
+}
+
 func (e *EnvList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	items := []yaml.MapItem{}
 
@@ -327,6 +335,8 @@ func (n Network) ParseInventory() ([]string, error) {
 	}
 
 	cmd := exec.Command("/bin/sh", "-c", n.Inventory)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, n.Env.Slice()...)
 	cmd.Stderr = os.Stderr
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
`--env` and `-e` env variables set on the CLI will now overwrite `env` set on the `network` level. This supports use cases where users want to access environment variables on the `inventory` call.