### PR TITLE
Support bastion command

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -137,6 +137,12 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 		network.Env.Set(env[:i], env[i+1:])
 	}
 
+	bastion, err := network.ParseBastion()
+	if err != nil {
+		return nil, nil, err
+	}
+	network.Bastion = bastion
+
 	hosts, err := network.ParseInventory()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Current use case where the bastion is a static string is unchanged. If given a command, will take the first line of the output of that command as the bastion string.