### PR TITLE
- don't clobber network.Hosts map when looping over the parsed sshcon…

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -321,12 +321,12 @@ func main() {
 		}
 
 		// check network.Hosts for match
-		for _, host := range network.Hosts {
+		for k, host := range network.Hosts {
 			conf, found := confMap[host]
 			if found {
 				network.User = conf.User
 				network.IdentityFile = resolvePath(conf.IdentityFile)
-				network.Hosts = []string{fmt.Sprintf("%s:%d", conf.HostName, conf.Port)}
+				network.Hosts[k] = fmt.Sprintf("%s:%d", conf.HostName, conf.Port)
 			}
 		}
 	}


### PR DESCRIPTION
…fig for matching hosts

Am I confused? Without this fix if the sshconfig matches even just one host then the run command is only run on that host, or it just runs on the first host the range loop gives a match, the fact that all hosts should have the same user and ssh key maybe is confusing...