### PR TITLE
Fixes #142 - ssh config fallback on Host

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -322,8 +322,11 @@ func main() {
 
 		// check network.Hosts for match
 		for _, host := range network.Hosts {
-			conf, found := confMap[host]
-			if found {
+			if conf, ok := confMap[host]; ok {
+				// attempt fallback on Host definition when HostName is omitted
+				if conf.HostName == "" {
+					conf.HostName = host
+				}
 				network.User = conf.User
 				network.IdentityFile = resolvePath(conf.IdentityFile)
 				network.Hosts = []string{fmt.Sprintf("%s:%d", conf.HostName, conf.Port)}


### PR DESCRIPTION
When reading from ssh config file, attempt fallback on Host definition when HostName is omitted