### PR TITLE
Ignore unreachable client error

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -26,6 +26,7 @@ var (
 
 	debug         bool
 	disablePrefix bool
+	ignoreError   bool
 
 	showVersion bool
 	showHelp    bool
@@ -60,6 +61,7 @@ func init() {
 	flag.BoolVar(&debug, "D", false, "Enable debug mode")
 	flag.BoolVar(&debug, "debug", false, "Enable debug mode")
 	flag.BoolVar(&disablePrefix, "disable-prefix", false, "Disable hostname prefix")
+	flag.BoolVar(&ignoreError, "ignore-error", false, "Ignore unreachable client error")
 
 	flag.BoolVar(&showVersion, "v", false, "Print version")
 	flag.BoolVar(&showVersion, "version", false, "Print version")
@@ -373,6 +375,7 @@ func main() {
 	}
 	app.Debug(debug)
 	app.Prefix(!disablePrefix)
+	app.Ignore(ignoreError)
 
 	// Run all the commands in the given network.
 	err = app.Run(network, vars, commands...)

--- a/sup.go
+++ b/sup.go
@@ -19,6 +19,7 @@ type Stackup struct {
 	conf   *Supfile
 	debug  bool
 	prefix bool
+	ignore bool
 }
 
 func New(conf *Supfile) (*Stackup, error) {
@@ -106,7 +107,11 @@ func (sup *Stackup) Run(network *Network, envVars EnvList, commands ...*Command)
 		clients = append(clients, client)
 	}
 	for err := range errCh {
-		return errors.Wrap(err, "connecting to clients failed")
+		if sup.ignore {
+			fmt.Fprintf(os.Stderr, "%v\n", errors.Wrap(err, "connecting to clients failed"))
+		} else {
+			return errors.Wrap(err, "connecting to clients failed")
+		}
 	}
 
 	// Run command or run multiple commands defined by target sequentially.
@@ -246,4 +251,8 @@ func (sup *Stackup) Debug(value bool) {
 
 func (sup *Stackup) Prefix(value bool) {
 	sup.prefix = value
+}
+
+func (sup *Stackup) Ignore(value bool) {
+	sup.ignore = value
 }


### PR DESCRIPTION
When some hosts from a group are unreachable, sup actually exits on the first SSH error. I propose the option flag "ignore-error" that just logs (instead return) when an host is not reachable.