### PR TITLE
ssh: Specify HostKeyCallback in ClientConfig

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -139,6 +139,9 @@ func (c *SSHClient) ConnectWith(host string, dialer SSHDialFunc) error {
 		Auth: []ssh.AuthMethod{
 			authMethod,
 		},
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			return nil
+		},
 	}
 
 	c.conn, err = dialer("tcp", c.host, config)


### PR DESCRIPTION
Since golang/go#19767 SSH library requires this field on each connection.

Currently all new installations of sup via `go get` doesn't work at all.
This commit fixes it.