### PR TITLE
Add SUPFILE_DIR as default environment variable

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -109,6 +109,11 @@ func cmdUsage(conf *sup.Supfile) {
 func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 	var commands []*sup.Command
 
+	// In case of the conf.Env needs an initialization
+	if conf.Env == nil {
+		conf.Env = make(sup.EnvList, 0)
+	}
+
 	args := flag.Args()
 	if len(args) < 1 {
 		networkUsage(conf)
@@ -122,26 +127,14 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 		return nil, nil, ErrUnknownNetwork
 	}
 
-	// Parse CLI --env flag env vars, override values defined in Network env.
-	for _, env := range envVars {
-		if len(env) == 0 {
-			continue
-		}
-		i := strings.Index(env, "=")
-		if i < 0 {
-			if len(env) > 0 {
-				network.Env.Set(env, "")
-			}
-			continue
-		}
-		network.Env.Set(env[:i], env[i+1:])
-	}
-
-	hosts, err := network.ParseInventory()
+	hosts, err := network.ParseInventory(conf.Env)
 	if err != nil {
 		return nil, nil, err
 	}
 	network.Hosts = append(network.Hosts, hosts...)
+	if network.Env == nil {
+		network.Env = make(sup.EnvList, 0)
+	}
 
 	// Does the <network> have at least one host?
 	if len(network.Hosts) == 0 {
@@ -155,26 +148,8 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 		return nil, nil, ErrUsage
 	}
 
-	// In case of the network.Env needs an initialization
-	if network.Env == nil {
-		network.Env = make(sup.EnvList, 0)
-	}
-
 	// Add default env variable with current network
 	network.Env.Set("SUP_NETWORK", args[0])
-
-	// Add default nonce
-	network.Env.Set("SUP_TIME", time.Now().UTC().Format(time.RFC3339))
-	if os.Getenv("SUP_TIME") != "" {
-		network.Env.Set("SUP_TIME", os.Getenv("SUP_TIME"))
-	}
-
-	// Add user
-	if os.Getenv("SUP_USER") != "" {
-		network.Env.Set("SUP_USER", os.Getenv("SUP_USER"))
-	} else {
-		network.Env.Set("SUP_USER", os.Getenv("USER"))
-	}
 
 	for _, cmd := range args[1:] {
 		// Target?
@@ -248,7 +223,14 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	conf, err := sup.NewSupfile(data)
+	conf, err := sup.NewSupfile(data,
+		// SUPFILE_DIR might change as sup invocations are chained.
+		sup.WithEnv("SUPFILE_DIR", filepath.Dir(supfile)),
+		// Add default nonce, but inherit from previous invocation.
+		sup.WithInheritEnv("SUP_TIME", time.Now().UTC().Format(time.RFC3339)),
+		// Add user, but inherit from previous invocation.
+		sup.WithInheritEnv("SUP_USER", os.Getenv("USER")),
+	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -331,15 +313,6 @@ func main() {
 		}
 	}
 
-	var vars sup.EnvList
-	for _, val := range append(conf.Env, network.Env...) {
-		vars.Set(val.Key, val.Value)
-	}
-	if err := vars.ResolveValues(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
 	// Parse CLI --env flag env vars, define $SUP_ENV and override values defined in Supfile.
 	var cliVars sup.EnvList
 	for _, env := range envVars {
@@ -349,11 +322,10 @@ func main() {
 		i := strings.Index(env, "=")
 		if i < 0 {
 			if len(env) > 0 {
-				vars.Set(env, "")
+				cliVars.Set(env, "")
 			}
 			continue
 		}
-		vars.Set(env[:i], env[i+1:])
 		cliVars.Set(env[:i], env[i+1:])
 	}
 
@@ -363,7 +335,7 @@ func main() {
 	for _, v := range cliVars {
 		supEnv += fmt.Sprintf(" -e %v=%q", v.Key, v.Value)
 	}
-	vars.Set("SUP_ENV", strings.TrimSpace(supEnv))
+	cliVars.Set("SUP_ENV", strings.TrimSpace(supEnv))
 
 	// Create new Stackup app.
 	app, err := sup.New(conf)
@@ -375,7 +347,7 @@ func main() {
 	app.Prefix(!disablePrefix)
 
 	// Run all the commands in the given network.
-	err = app.Run(network, vars, commands...)
+	err = app.Run(network, cliVars, commands...)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/example/Supfile
+++ b/example/Supfile
@@ -14,6 +14,8 @@ env:
 networks:
   # Groups of hosts
   local:
+    env:
+      SUP_LOCAL: yessir
     hosts:
       - localhost
 
@@ -53,7 +55,7 @@ commands:
     upload:
       - src: ./
         dst: /tmp/$IMAGE
-    script: ./scripts/docker-build.sh
+    script: $SUPFILE_DIR/scripts/docker-build.sh
     once: true
 
   pull:
@@ -125,6 +127,10 @@ commands:
     local: >
       curl -X POST --data-urlencode 'payload={"channel": "#_team_", "text": "['$SUP_NETWORK'] '$SUP_USER' deployed '$NAME'"}' \
         https://hooks.slack.com/services/X/Y/Z
+
+  env:
+    desc: Print environment
+    local: env
 
   bash:
     desc: Interactive shell on all hosts

--- a/localhost.go
+++ b/localhost.go
@@ -6,11 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-
-	"github.com/pkg/errors"
 )
 
-// Client is a wrapper over the SSH connection/sessions.
+// LocalhostClient is a wrapper over the SSH connection/sessions.
 type LocalhostClient struct {
 	cmd     *exec.Cmd
 	user    string
@@ -104,16 +102,4 @@ func (c *LocalhostClient) WriteClose() error {
 
 func (c *LocalhostClient) Signal(sig os.Signal) error {
 	return c.cmd.Process.Signal(sig)
-}
-
-func ResolveLocalPath(cwd, path, env string) (string, error) {
-	// Check if file exists first. Use bash to resolve $ENV_VARs.
-	cmd := exec.Command("bash", "-c", env+"echo -n "+path)
-	cmd.Dir = cwd
-	resolvedFilename, err := cmd.Output()
-	if err != nil {
-		return "", errors.Wrap(err, "resolving path failed")
-	}
-
-	return string(resolvedFilename), nil
 }

--- a/ssh.go
+++ b/ssh.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-// Client is a wrapper over the SSH connection/sessions.
+// SSHClient is a wrapper over the SSH connection/sessions.
 type SSHClient struct {
 	conn         *ssh.Client
 	sess         *ssh.Session
@@ -219,16 +219,16 @@ func (c *SSHClient) Wait() error {
 }
 
 // DialThrough will create a new connection from the ssh server sc is connected to. DialThrough is an SSHDialer.
-func (sc *SSHClient) DialThrough(net, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
-	conn, err := sc.conn.Dial(net, addr)
+func (c *SSHClient) DialThrough(net, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
+	conn, err := c.conn.Dial(net, addr)
 	if err != nil {
 		return nil, err
 	}
-	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
+	sc, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
 		return nil, err
 	}
-	return ssh.NewClient(c, chans, reqs), nil
+	return ssh.NewClient(sc, chans, reqs), nil
 
 }
 


### PR DESCRIPTION
This will allow Supfiles to be run different directories and
consistently resolve files relative to the Supfile.

This CL contains refactors the resolution order of environment
variables such that it's a bit easier to reason about.

Fixes #99