### PR TITLE
Allow inventory commands to recognize top-level env vars

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -137,7 +137,7 @@ func parseArgs(conf *sup.Supfile) (*sup.Network, []*sup.Command, error) {
 		network.Env.Set(env[:i], env[i+1:])
 	}
 
-	hosts, err := network.ParseInventory()
+	hosts, err := network.ParseInventory(conf)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/supfile.go
+++ b/supfile.go
@@ -329,13 +329,14 @@ func NewSupfile(data []byte) (*Supfile, error) {
 
 // ParseInventory runs the inventory command, if provided, and appends
 // the command's output lines to the manually defined list of hosts.
-func (n Network) ParseInventory() ([]string, error) {
+func (n Network) ParseInventory(conf *Supfile) ([]string, error) {
 	if n.Inventory == "" {
 		return nil, nil
 	}
 
 	cmd := exec.Command("/bin/sh", "-c", n.Inventory)
 	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, conf.Env.Slice()...)
 	cmd.Env = append(cmd.Env, n.Env.Slice()...)
 	cmd.Stderr = os.Stderr
 	output, err := cmd.Output()


### PR DESCRIPTION
fixes: https://github.com/pressly/sup/issues/97

I tried this locally and it seems to work as expected. i.e. env vars passed via `-e` take precedence over top-level `env` entries. This could potentially be a breaking change, so I'm open to suggestions on versioning, etc.